### PR TITLE
Fix region for customer address

### DIFF
--- a/lib/magento/customer_address.rb
+++ b/lib/magento/customer_address.rb
@@ -33,10 +33,6 @@ module MagentoAPI
       MagentoAPI::Country.find(self.country_id)
     end
 
-    def region
-      MagentoAPI::Region.find_by_country_and_id(self.country_id, self.region_id)
-    end
-
     def update_attribute(name, value)
       @attributes[name] = value
       self.class.update(self.id, Hash[*[name.to_sym, value]])


### PR DESCRIPTION
`MagentoAPI::Region.find_by_country_and_id(self.country_id, self.region_id)` fails on fetching `region` with error:

```
MagentoAPI::ApiError:
       101 -> Invalid country code: Array
```

Since region is already available from the object attributes, not required to do a fetch from server.